### PR TITLE
Update .NET version to 8.x in workflows

### DIFF
--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -9,7 +9,7 @@ on:
 env:
   AZURE_WEBAPP_NAME: tinycms
   AZURE_WEBAPP_PACKAGE_PATH: './published'
-  NET_VERSION: '7.x'
+  NET_VERSION: '8.x'
   PROJECT_NAME: src/TinyCms
   RUNTIME: win-x86
   

--- a/.github/workflows/publish_database.yml
+++ b/.github/workflows/publish_database.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '7.x'
+  NET_VERSION: '8.x'
   DATABASE_PROJECT_FILE: database/TinyCms.Database.sqlproj
 
 jobs:


### PR DESCRIPTION
Updated the NET_VERSION environment variable from 7.x to 8.x in both deploy_site.yml and publish_database.yml workflow files. This change ensures that the site deployment and database publishing processes are compatible with and utilize the .NET 8.x runtime.